### PR TITLE
Enable support inside other regions

### DIFF
--- a/autoload/jspretmpl.vim
+++ b/autoload/jspretmpl.vim
@@ -54,7 +54,7 @@ function! jspretmpl#applySyntax(filetype, startCondition)
     let regexp_skip = '\\`'
     let regexp_end = '`'
     let group_def = 'start="'.regexp_start.'" skip="'.regexp_skip.'" end="'.regexp_end.'"'
-    execute 'syntax region '.region.' matchgroup=EcmaScriptTemplateStrings '.group_def.' keepend contains=@'.group
+    execute 'syntax region '.region.' matchgroup=EcmaScriptTemplateStrings '.group_def.' keepend contains=@'.group.' containedin=jsTaggedTemplate'
   elseif &ft == 'coffee' || &ft == 'dart'
     let regexp_start = '"""'
     let regexp_end = '"""'


### PR DESCRIPTION
Fixes https://github.com/Quramy/vim-js-pretty-template/issues/4 on my setup. Might depend on https://github.com/pangloss/vim-javascript. This fix might work for Typescript, but I don't use it so I haven't tested it. And I don't use Coffeescript or Dart so I didn't fix it for them either.