### PR TITLE
Support JSX filetypes

### DIFF
--- a/autoload/jspretmpl.vim
+++ b/autoload/jspretmpl.vim
@@ -45,7 +45,7 @@ function! jspretmpl#applySyntax(filetype, startCondition)
   let group = s:tmplSyntaxGroup(a:filetype)
   let region = s:tmplSyntaxRegion(a:filetype)
   let b:jspre_current_ft = a:filetype
-  if &ft == 'javascript' || &ft == 'typescript'
+  if &ft == 'javascript' || &ft == 'typescript' || &ft == 'jsx' || &ft == 'javascript.jsx'
     if strlen(a:startCondition)
       let regexp_start = a:startCondition
     else


### PR DESCRIPTION
The [`vim-jsx`](https://github.com/mxw/vim-jsx/blob/d96a4480f1689ce357644042c300e0e14170507e/ftdetect/javascript.vim#L36-L37) plugin uses a filetype of `javascript.jsx`. Presumably, others will use a filetype of `jsx`.

This change brings in support for both of them.