### PR TITLE
Remove default highlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var htmlTempl = `
 
 Template Strings is available with [Babel](https://babeljs.io/), [google/traceur-compile](https://github.com/google/traceur-compiler) and [TypeScript](http://www.typescriptlang.org/).
 
-## How to install 
+## How to install
 
 ### Vundle
 
@@ -56,40 +56,20 @@ git clone https://github.com/Quramy/vim-js-pretty-template
 
 ## Usage
 
-This plugin provides the `:JsPreTmpl` command.  For example:
-
-```vim
-:JsPreTmpl html
-```
-
-Executing the above, a template string is highlighted with HTML way.
-
-This command requires an argument. It's a `FileType` name which you can apply into templates in your JavaScript code.
-
-If you want to apply automatically, you can append the following to your `.vimrc`:
-
-```vim
-autocmd FileType javascript JsPreTmpl html
-```
-
 ### Tagged Template Literal
-You can override the default rule defined `:JsPreTml` command with another rule using `jspretmpl#register_tag()` function. For example,
+Set the highlighting of template strings with the  `jspretmpl#register_tag()` function. For example,
 
 ```vim
 " Register tag name associated the filetype
 call jspretmpl#register_tag('gql', 'graphql')
 
-autocmd FileType javascript JsPreTmpl html
+autocmd FileType javascript JsPreTmpl
+autocmd FileType javascript.jsx JsPreTmpl
 ```
 
 Then your JavaScript codes are Highlighted as the following:
 
 ```javascript
-// HTML way default
-const template = `
-  <div>html</div>
-`;
-
 // GraphQL way if gql tagged
 const query = gql`
   fragment on User {
@@ -109,7 +89,7 @@ vim-js-pretty-template is also compatible for TypeScript, Dart and CoffeeScript.
 For example:
 
 ```vim
-autocmd FileType typescript JsPreTmpl markdown
+autocmd FileType typescript JsPreTmpl
 autocmd FileType typescript syn clear foldBraces " For leafgarland/typescript-vim users only. Please see #1 for details.
 ```
 
@@ -125,10 +105,10 @@ var tmpl: string = `
 or for example:
 
 ```vim
-autocmd FileType dart JsPreTmpl xml
+autocmd FileType dart JsPreTmpl
 ```
 
-then: 
+then:
 
 ```dart
 var tmpl = """

--- a/autoload/jspretmpl.vim
+++ b/autoload/jspretmpl.vim
@@ -83,21 +83,11 @@ function! jspretmpl#register_tag(tagname, filetype)
   call jspretmpl#addRule(a:filetype, a:tagname.'`')
 endfunction
 
-function! jspretmpl#loadAndApply(...)
-  if a:0 == 0
-    return
-  endif
+function! jspretmpl#loadAndApply()
   for k in keys(s:rule_map)
     call jspretmpl#loadOtherSyntax(k)
     call jspretmpl#applySyntax(k, s:rule_map[k])
   endfor
-  let l:ft = a:1
-  call jspretmpl#loadOtherSyntax(l:ft)
-  if !len(keys(s:rule_map))
-    call jspretmpl#applySyntax(l:ft, '')
-  else
-    call jspretmpl#applySyntax(l:ft, '`')
-  endif
 endfunction
 
 function! jspretmpl#clear()

--- a/plugin/jspretmpl.vim
+++ b/plugin/jspretmpl.vim
@@ -12,7 +12,7 @@ let g:loaded_js_pretty_template = 1
 let s:save_cpo = &cpo
 set cpo&vim
 
-command! -nargs=1 -complete=filetype JsPreTmpl : call jspretmpl#loadAndApply(<f-args>)
+command! -nargs=0 -complete=filetype JsPreTmpl : call jspretmpl#loadAndApply()
 command! JsPreTmplClear : call jspretmpl#clear()
 
 let &cpo = s:save_cpo


### PR DESCRIPTION
Template literals have gained in popularity within the JS ecosystem, with more and more libraries (particularly in the css-in-js space) using them.

The default highlighter provided by this plugin causes most of those template literals to be highlighted as `html`, which can make the plugin appear broken.

This PR removes the default, instead leaving it up to the user to specify what highlighting they prefer under what circumstances.